### PR TITLE
Lock down to Rails ~>4.0

### DIFF
--- a/backport_new_renderer.gemspec
+++ b/backport_new_renderer.gemspec
@@ -3,9 +3,9 @@ Gem::Specification.new do |s|
   s.author       = 'brainopia'
   s.summary      = 'Backport render anywhere feature from rails 5'
   s.version      = '1.0.0'
- 
+
   s.files        = 'backport_new_renderer.rb'
   s.require_path = '.'
 
-  s.add_runtime_dependency 'rails'
+  s.add_runtime_dependency 'rails', '~> 4.0'
 end

--- a/backport_new_renderer.gemspec
+++ b/backport_new_renderer.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |s|
   s.name         = 'backport_new_renderer'
   s.author       = 'brainopia'
+  s.homepage     = 'https://github.com/brainopia/backport_new_renderer'
   s.summary      = 'Backport render anywhere feature from rails 5'
   s.version      = '1.0.0'
 


### PR DESCRIPTION
As this isn't needed with Rails 5+, and likely won't work will older (and no longer supported) Rails versions < 4.
